### PR TITLE
fix for product form validation not firing when using AJAX addToCart

### DIFF
--- a/assets/radiance.js
+++ b/assets/radiance.js
@@ -72,7 +72,7 @@ var RADIANCE = {
 
   templateProduct : {
     init: function(){
-      $('#add-to-cart').bind( 'click', addToCart );
+      $('#product-actions').bind( 'submit', addToCart );
       $('#product-gallery.zoom-in').enhanceGallery();
       $('#thumbs li:nth-child(5n+5)').addClass('last-in-row');
     }
@@ -194,7 +194,7 @@ function addToCart(e){
 
   if (typeof e !== 'undefined') e.preventDefault();
 
-  var form      = $(this).parents('form');
+  var form      = $(this);
 
   $.ajax({
     type: 'POST',


### PR DESCRIPTION
The issue is caused when using Line Item Properties. If, for example, a text input is added to the product form and we want to mark that input as required, the required validation would be ignored by radiance. This is because the addToCart method was bound to the click event of the 'AddToCart' button. The method is now bound to the submit method of the form itself, which causes the browser to validate the form before allowing it to be submitted. 
