### PR TITLE
When a form contains a file upload, prevent ajax Add to Cart

### DIFF
--- a/assets/radiance.js
+++ b/assets/radiance.js
@@ -191,10 +191,11 @@ function setupDropdownMenus(){
  * Ajaxy add-to-cart
  */
 function addToCart(e){
+	
+	var form = $(this);
+	if (form !== 'undefined' and form.attr('enctype') === "multipart/form-data") return;
 
   if (typeof e !== 'undefined') e.preventDefault();
-
-  var form      = $(this);
 
   $.ajax({
     type: 'POST',


### PR DESCRIPTION
If the Product form contains attribute enctype="multipart/form-data", it means that it probably contains a file upload. Since file uploads don't work with Ajax, let's disable Ajax when this attribute is detected.

This allows merchants to keep using the Ajax feature for all their products where file uploads are not needed. Currently, the merchant has to disable Ajax for all products, even if only one of their products contains a file upload input.
